### PR TITLE
%fixed crash when using cpuminer <=v2.1.3

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -339,7 +339,7 @@ void MainWindow::readProcessOutput()
             QString line = list.at(i);
 
             // Ignore protocol dump
-            if (!line.startsWith("[") || line.contains("JSON protocol") || line.contains("HTTP hdr"))
+            if (!line.startsWith("[") || line.contains("JSON protocol") || line.contains("HTTP hdr") || line.contains("threads started"))
                 continue;
 
             if (line.contains("Long-polling activated for"))
@@ -359,6 +359,7 @@ void MainWindow::readProcessOutput()
 
             else if (line.contains("The requested URL returned error: 403"))
                 reportToList("Couldn't connect. Try checking your username and password.", ERROR, NULL);
+
             else if (line.contains("workio thread dead, exiting."))
             {
                 reportToList("Miner exited. Restarting automatically.", ERROR, NULL);


### PR DESCRIPTION
well atleast i think its fixed ... reason for crash is output is a bit diff due to pooler removed the 1sec sleep at start 

https://github.com/pooler/cpuminer/commit/46fe063865d8e2f807a9fb40df3144cd31824a1b
http://pastie.org/3409052
