### PR TITLE
Fix handling of additional parameters

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -188,7 +188,7 @@ QStringList MainWindow::getArgs()
     args << "--userpass" << userpassLine.toAscii();
     args << "--threads" << ui->threadsBox->currentText().toAscii();
     args << "-P";
-    args << ui->parametersLine->text().toAscii();
+    args << ui->parametersLine->text().split(" ", QString::SkipEmptyParts);
 
     return args;
 }


### PR DESCRIPTION
The user-supplied string of additional parameters needs to be parsed, otherwise it is passed to the miner as a single parameter.
In particular, the empty string was passed to the miner as-is, and this caused cpuminer 2.1.3 to throw an "unsupported non-option argument" error.
